### PR TITLE
main.cpp: fix typo for macros #else

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -129,7 +129,7 @@ int main(int argc, char** argv) {
 
         #if defined(_WIN32)
         std::this_thread::sleep_for(std::chrono::microseconds(500000));
-        #elsekey
+        #else
         usleep(500000);
         #endif 
 


### PR DESCRIPTION
fix for the issue: https://github.com/patriciogonzalezvivo/MidiGyver/issues/3